### PR TITLE
Refactor VirtIO MMIO register map handling

### DIFF
--- a/common.h
+++ b/common.h
@@ -16,3 +16,12 @@ static inline int ilog2(int x)
 {
     return 31 - __builtin_clz(x | 1);
 }
+
+/* Range check
+ * For any variable range checking:
+ *     if (x >= minx && x <= maxx) ...
+ * it is faster to use bit operation:
+ *     if ((signed)((x - minx) | (maxx - x)) >= 0) ...
+ */
+#define RANGE_CHECK(x, minx, size) \
+    ((int32_t) ((x - minx) | (minx + size - 1 - x)) >= 0)

--- a/device.h
+++ b/device.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "riscv.h"
+#include "virtio.h"
 
 /* RAM */
 
@@ -100,6 +101,8 @@ typedef struct {
     /* supplied by environment */
     int tap_fd;
     uint32_t *ram;
+    /* implementation-specific */
+    void *priv;
 } virtio_net_state_t;
 
 void virtio_net_read(vm_t *core,
@@ -147,7 +150,8 @@ typedef struct {
     /* supplied by environment */
     uint32_t *ram;
     uint32_t *disk;
-    uint64_t capacity;
+    /* implementation-specific */
+    void *priv;
 } virtio_blk_state_t;
 
 void virtio_blk_read(vm_t *vm,

--- a/virtio.h
+++ b/virtio.h
@@ -24,6 +24,39 @@
 #define VIRTIO_BLK_S_IOERR 1
 #define VIRTIO_BLK_S_UNSUPP 2
 
+/* VirtIO MMIO registers */
+#define VIRTIO_REG_LIST                  \
+    _(MagicValue, 0x000)        /* R */  \
+    _(Version, 0x004)           /* R */  \
+    _(DeviceID, 0x008)          /* R */  \
+    _(VendorID, 0x00c)          /* R */  \
+    _(DeviceFeatures, 0x010)    /* R */  \
+    _(DeviceFeaturesSel, 0x014) /* W */  \
+    _(DriverFeatures, 0x020)    /* W */  \
+    _(DriverFeaturesSel, 0x024) /* W */  \
+    _(QueueSel, 0x030)          /* W */  \
+    _(QueueNumMax, 0x034)       /* R */  \
+    _(QueueNum, 0x038)          /* W */  \
+    _(QueueReady, 0x044)        /* RW */ \
+    _(QueueNotify, 0x050)       /* W */  \
+    _(InterruptStatus, 0x60)    /* R */  \
+    _(InterruptACK, 0x064)      /* W */  \
+    _(Status, 0x070)            /* RW */ \
+    _(QueueDescLow, 0x080)      /* W */  \
+    _(QueueDescHigh, 0x084)     /* W */  \
+    _(QueueDriverLow, 0x090)    /* W */  \
+    _(QueueDriverHigh, 0x094)   /* W */  \
+    _(QueueDeviceLow, 0x0a0)    /* W */  \
+    _(QueueDeviceHigh, 0x0a4)   /* W */  \
+    _(ConfigGeneration, 0x0fc)  /* R */  \
+    _(Config, 0x100)            /* RW */
+
+enum {
+#define _(reg, addr) VIRTIO_##reg = addr >> 2,
+    VIRTIO_REG_LIST
+#undef _
+};
+
 struct virtq_desc {
     uint32_t addr;
     uint32_t len;


### PR DESCRIPTION
Two adjustments are conducted in this pull request:
1. Replace the hard-coded register address checking with enum.
2. Handle the configuration space read / write with device-specific structures.