### PR TITLE
Fix undefined behavior in RV_MARCHID definition

### DIFF
--- a/main.c
+++ b/main.c
@@ -185,7 +185,7 @@ static inline sbi_ret_t handle_sbi_ecall_RST(vm_t *vm, int32_t fid)
 }
 
 #define RV_MVENDORID 0x12345678
-#define RV_MARCHID ((1 << 31) | 1)
+#define RV_MARCHID ((1ULL << 31) | 1)
 #define RV_MIMPID 1
 
 static inline sbi_ret_t handle_sbi_ecall_BASE(vm_t *vm, int32_t fid)


### PR DESCRIPTION
The RV_MARCHID macro is defined using a left shift operation without explicitly specifying the type of the constant. This can lead to undefined behavior, specifically a shift too many bits issue.

Modify the RV_MARCHID definition to use the ULL suffix for the constant, ensuring it is treated as an unsigned long long. This eliminates the undefined behavior.