### PR TITLE
CI: Automate the runtime checks

### DIFF
--- a/.ci/autorun.sh
+++ b/.ci/autorun.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+pkill -9 semu
+
+expect <<DONE
+set timeout 120
+spawn make check
+expect "buildroot login:" { send "root\n" } timeout { exit 1 }
+expect "# " { send "uname -a\n" } timeout { exit 2 }
+expect "riscv32 GNU/Linux" { send "\x01"; send "x" } timeout { exit 3 }
+DONE
+
+ret=$?
+pkill -9 semu
+echo
+
+MESSAGES=("OK!" \
+     "Fail to boot" \
+     "Fail to login" \
+     "Fail to run commands" \
+)
+
+echo "${MESSAGES[$ret]}"
+exit ${ret}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,12 @@ jobs:
     - name: install-dependencies
       run: | 
             sudo apt-get install build-essential device-tree-compiler
+            sudo apt-get install expect
     - name: default build
       run: make
+      shell: bash
+    - name: automated test
+      run: .ci/autorun.sh
       shell: bash
 
   coding_style:
@@ -21,5 +25,5 @@ jobs:
     - name: coding convention
       run: |
             sudo apt-get install -q -y clang-format-12
-            sh .ci/check-format.sh
+            .ci/check-format.sh
       shell: bash


### PR DESCRIPTION
This commit aims to automate the validation process by utilizing the 'expect' tool to verify if semu can successfully boot the Linux kernel and run BusyBox as anticipated. Currently, only the "uname" command is executed and its output is checked.