### PR TITLE
Decouple interrupt bit index calculation from ilog2

### DIFF
--- a/common.h
+++ b/common.h
@@ -14,8 +14,19 @@
 /* Ensure that __builtin_clz is never called with 0 argument */
 static inline int ilog2(int x)
 {
-    return 31 - __builtin_clz(x | 1);
+    return __builtin_clz(x | 1);
 }
+
+/*
+ * Note: only applicable to 32-bit number
+ *
+ * Example output:
+ * GET_INTR_IDX(1) = 0
+ * GET_INTR_IDX(2) = 1
+ * GET_INTR_IDX(4) = 2
+ * GET_INTR_IDX(8) = 3
+ */
+#define GET_INTR_IDX(x) (31 - ilog2(x))
 
 /* Range check
  * For any variable range checking:

--- a/plic.c
+++ b/plic.c
@@ -38,7 +38,7 @@ static bool plic_reg_read(plic_state_t *plic, uint32_t addr, uint32_t *value)
         *value = 0;
         uint32_t candidates = plic->ip & plic->ie;
         if (candidates) {
-            *value = ilog2(candidates);
+            *value = GET_INTR_IDX(candidates);
             plic->ip &= ~(1 << (*value));
         }
         return true;

--- a/riscv.c
+++ b/riscv.c
@@ -794,7 +794,7 @@ void vm_step(vm_t *vm)
 
     if ((vm->sstatus_sie || !vm->s_mode) && (vm->sip & vm->sie)) {
         uint32_t applicable = (vm->sip & vm->sie);
-        uint8_t idx = ilog2(applicable);
+        uint8_t idx = GET_INTR_IDX(applicable);
         vm->exc_cause = (1U << 31) | idx;
         vm->stval = 0;
         vm_trap(vm);

--- a/uart.c
+++ b/uart.c
@@ -49,7 +49,7 @@ void u8250_update_interrupts(u8250_state_t *uart)
 
     /* Update current interrupt (higher bits -> more priority) */
     if (uart->pending_ints)
-        uart->current_int = ilog2(uart->pending_ints);
+        uart->current_int = GET_INTR_IDX(uart->pending_ints);
 }
 
 void u8250_check_ready(u8250_state_t *uart)


### PR DESCRIPTION
ilog2 is a common function, but interrupt bit index calculation is application dependent. Thus, decouple them and create a new macro called GET_INTR_IDX which leverages the ilog2 to calculate the interrupt bit index.