### PR TITLE
Implement basic ACLINT support for the MTIMER register

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ all: $(BIN) minimal.dtb
 OBJS := \
 	riscv.o \
 	ram.o \
+	timer.o \
+	aclint.o \
 	plic.o \
 	uart.o \
 	main.o \

--- a/aclint.c
+++ b/aclint.c
@@ -1,0 +1,128 @@
+#include "device.h"
+#include "riscv.h"
+#include "riscv_private.h"
+
+void aclint_timer_interrupts(vm_t *vm, aclint_state_t *aclint)
+{
+    uint64_t time_delta = aclint->mtimecmp - vm_timer_gettime(&vm->timer);
+    if ((time_delta & 0x8000000000000000) || time_delta == 0)
+        vm->sip |= RV_INT_STI_BIT;
+    else
+        vm->sip &= ~RV_INT_STI_BIT;
+}
+
+void aclint_update_interrupts(vm_t *vm, aclint_state_t *aclint)
+{
+    if (aclint->setssip)
+        vm->sip |= RV_INT_SSI_BIT;
+    else
+        vm->sip &= ~RV_INT_SSI_BIT;
+}
+
+static bool aclint_reg_read(aclint_state_t *aclint,
+                            uint32_t addr,
+                            uint32_t *value)
+{
+#define _(reg) ACLINT_##reg
+    switch (addr) {
+    case _(SSWI):
+        /* sswi */
+        *value = aclint->setssip;
+        return true;
+    case _(MTIMECMP_LO):
+        /* mtimecmp */
+        *value = aclint->mtimecmp & 0xFFFFFFFF;
+        return true;
+    case _(MTIMECMP_HI):
+        /* mtimecmph */
+        *value = (aclint->mtimecmp >> 32) & 0xFFFFFFFF;
+        return true;
+    case _(MTIME_LO):
+        /* mtime */
+        *value = (uint32_t) (vm_timer_gettime(&aclint->mtimer) & 0xFFFFFFFF);
+        return true;
+    case _(MTIME_HI):
+        /* mtimeh */
+        *value =
+            (uint32_t) (vm_timer_gettime(&aclint->mtimer) >> 32) & 0xFFFFFFFF;
+        return true;
+    default:
+        return false;
+    }
+#undef _
+}
+
+static bool aclint_reg_write(aclint_state_t *aclint,
+                             uint32_t addr,
+                             uint32_t value)
+{
+#define _(reg) ACLINT_##reg
+    switch (addr) {
+    case _(SSWI):
+        /* sswi */
+        aclint->setssip = value;
+        return true;
+    case _(MTIMECMP_LO):
+        /* mtimecmp */
+        aclint->mtimecmp |= value;
+        return true;
+    case _(MTIMECMP_HI):
+        /* mtimecmph */
+        aclint->mtimecmp |= ((uint64_t) value) << 32;
+        return true;
+    case _(MTIME_LO):
+        /* mtime */
+        vm_timer_rebase(&aclint->mtimer, value);
+        return true;
+    case _(MTIME_HI):
+        /* mtimeh */
+        vm_timer_rebase(&aclint->mtimer, ((uint64_t) value) << 32);
+        return true;
+    default:
+        return false;
+    }
+#undef _
+}
+
+void aclint_read(vm_t *vm,
+                 aclint_state_t *aclint,
+                 uint32_t addr,
+                 uint8_t width,
+                 uint32_t *value)
+{
+    switch (width) {
+    case RV_MEM_LW:
+        if (!aclint_reg_read(aclint, addr >> 2, value))
+            vm_set_exception(vm, RV_EXC_LOAD_FAULT, vm->exc_val);
+        break;
+    case RV_MEM_LBU:
+    case RV_MEM_LB:
+    case RV_MEM_LHU:
+    case RV_MEM_LH:
+        vm_set_exception(vm, RV_EXC_LOAD_MISALIGN, vm->exc_val);
+        return;
+    default:
+        vm_set_exception(vm, RV_EXC_ILLEGAL_INSN, 0);
+        return;
+    }
+}
+void aclint_write(vm_t *vm,
+                  aclint_state_t *aclint,
+                  uint32_t addr,
+                  uint8_t width,
+                  uint32_t value)
+{
+    switch (width) {
+    case RV_MEM_SW:
+        if (!aclint_reg_write(aclint, addr >> 2, value))
+            vm_set_exception(vm, RV_EXC_STORE_FAULT, vm->exc_val);
+        break;
+    case RV_MEM_SB:
+    case RV_MEM_SH:
+        vm_set_exception(vm, RV_EXC_STORE_MISALIGN, vm->exc_val);
+        return;
+    default:
+        vm_set_exception(vm, RV_EXC_ILLEGAL_INSN, 0);
+        return;
+    }
+}

--- a/minimal.dts
+++ b/minimal.dts
@@ -81,5 +81,11 @@
             interrupts = <3>;
         };
 #endif
+        clint0: clint@4400000 {
+            #interrupt-cells = <1>;
+            compatible = "sifive,clint0";
+            reg = <0x4400000 0x000C000>;
+            interrupts-extended = <&cpu0_intc 1 &cpu0_intc 5>;
+        };
     };
 };

--- a/plic.c
+++ b/plic.c
@@ -21,19 +21,19 @@ static bool plic_reg_read(plic_state_t *plic, uint32_t addr, uint32_t *value)
     /* no priority support: source priority hardwired to 1 */
     if (1 <= addr && addr <= 31)
         return true;
-
+#define _(reg) PLIC_##reg
     switch (addr) {
-    case 0x400:
+    case _(InterruptPending):
         *value = plic->ip;
         return true;
-    case 0x800:
+    case _(InterruptEnable):
         *value = plic->ie;
         return true;
-    case 0x80000:
+    case _(PriorityThresholds):
         *value = 0;
         /* no priority support: target priority threshold hardwired to 0 */
         return true;
-    case 0x80001:
+    case _(InterruptClaim):
         /* claim */
         *value = 0;
         uint32_t candidates = plic->ip & plic->ie;
@@ -45,6 +45,7 @@ static bool plic_reg_read(plic_state_t *plic, uint32_t addr, uint32_t *value)
     default:
         return false;
     }
+#undef _
 }
 
 static bool plic_reg_write(plic_state_t *plic, uint32_t addr, uint32_t value)
@@ -52,16 +53,16 @@ static bool plic_reg_write(plic_state_t *plic, uint32_t addr, uint32_t value)
     /* no priority support: source priority hardwired to 1 */
     if (1 <= addr && addr <= 31)
         return true;
-
+#define _(reg) PLIC_##reg
     switch (addr) {
-    case 0x800:
+    case _(InterruptEnable):
         value &= ~1;
         plic->ie = value;
         return true;
-    case 0x80000:
+    case _(PriorityThresholds):
         /* no priority support: target priority threshold hardwired to 0 */
         return true;
-    case 0x80001:
+    case _(InterruptCompletion):
         /* completion */
         if (plic->ie & (1 << value))
             plic->masked &= ~(1 << value);
@@ -69,6 +70,7 @@ static bool plic_reg_write(plic_state_t *plic, uint32_t addr, uint32_t value)
     default:
         return false;
     }
+#undef _
 }
 
 void plic_read(vm_t *vm,

--- a/riscv.h
+++ b/riscv.h
@@ -34,6 +34,16 @@ typedef struct {
     uint32_t *page_addr;
 } mmu_cache_t;
 
+/* TIMER */
+typedef struct {
+    uint64_t begin;
+    uint64_t freq;
+} vm_timer_t;
+
+uint64_t vm_timer_clocksource(uint64_t freq);
+uint64_t vm_timer_gettime(vm_timer_t *timer);
+void vm_timer_rebase(vm_timer_t *timer, uint64_t time);
+
 /* To use the emulator, start by initializing a vm_t object with zero values,
  * invoke vm_init(), and set the required environment-supplied callbacks. You
  * may also set other necessary fields such as argument registers and s_mode,
@@ -102,6 +112,9 @@ struct __vm_internal {
     uint32_t scounteren;
     uint32_t satp; /**< MMU */
     uint32_t *page_table;
+
+    /* Timer */
+    vm_timer_t timer;
 
     void *priv; /**< environment supplied */
 

--- a/riscv_private.h
+++ b/riscv_private.h
@@ -56,6 +56,13 @@ enum {
 
     /* S-mode (Supervisor Protection and Translation) */
     RV_CSR_SATP = 0x180, /**< Supervisor address translation and protection */
+
+    /* Unprivileged Timers */
+    RV_CSR_TIME = 0xC01, /**< Timer for RDTIME instruction */
+    RV_CSR_INSTRET =
+        0xC02, /**< Instructions-retired counter for RDINSTRET instruction */
+    RV_CSR_TIMEH = 0xC81,    /**< Upper 32 bits of time, RV32 only.*/
+    RV_CSR_INSTRETH = 0xC82, /**< Upper 32 bits of instret, RV32 only */
 };
 
 /* privileged ISA: exception causes */

--- a/timer.c
+++ b/timer.c
@@ -1,0 +1,41 @@
+#include <time.h>
+
+#include "riscv.h"
+
+#if defined(__APPLE__)
+#define HAVE_MACH_TIMER
+#include <mach/mach_time.h>
+#elif !defined(_WIN32) && !defined(_WIN64)
+#define HAVE_POSIX_TIMER
+#ifdef CLOCK_MONOTONIC
+#define CLOCKID CLOCK_MONOTONIC
+#else
+#define CLOCKID CLOCK_REALTIME
+#endif
+#endif
+
+uint64_t vm_timer_clocksource(uint64_t freq)
+{
+#if defined(HAVE_POSIX_TIMER)
+    struct timespec t;
+    clock_gettime(CLOCKID, &t);
+    return (t.tv_sec * freq) + (t.tv_nsec * freq / 1e9);
+#elif defined(HAVE_MACH_TIMER)
+    static mach_timebase_info_data_t t;
+    if (mach_clk.denom == 0)
+        (void) mach_timebase_info(&t);
+    return mach_absolute_time() * freq / t.denom * t.numer;
+#else
+    return time(0) * freq;
+#endif
+}
+
+uint64_t vm_timer_gettime(vm_timer_t *timer)
+{
+    return vm_timer_clocksource(timer->freq) - timer->begin;
+}
+
+void vm_timer_rebase(vm_timer_t *timer, uint64_t time)
+{
+    timer->begin = vm_timer_clocksource(timer->freq) - time;
+}


### PR DESCRIPTION
Replace the `timer` defined in the `emu_state_t` structure, which originally compared with the instruction counter and triggered software timer interrupts, with the MTIMER memory-mapped peripheral. For each HART (currently only one), there is an MTIMECMP register connected to the MTIMER device.

Additionally, use the TIMER Extension to program the clock for scheduling the next timer event.
```c
static inline sbi_ret_t handle_sbi_ecall_TIMER(vm_t *vm, int32_t fid)
{
    emu_state_t *data = PRIV(vm);
    switch (fid) {
    case SBI_TIMER__SET_TIMER:
        data->aclint.mtimecmp = (((uint64_t) vm->x_regs[RV_R_A1])) << 32 |
                                (uint64_t) vm->x_regs[RV_R_A0];
        return (sbi_ret_t){SBI_SUCCESS, 0};
    default:
        return (sbi_ret_t){SBI_ERR_NOT_SUPPORTED, 0};
    }
}
```

Replacing timer with MTIMER perpheral also triggers timer interrupts normally.

Clarify that the MTIMER peripheral can also trigger timer interrupts within a scheduled period by monitoring `/proc/interrupts` reveals an increase in timer interrupts triggered by `riscv-timer`:

```
  1:        595  SiFive PLIC   1 Edge      ttyS0
  2:         19  SiFive PLIC   3 Edge      virtio1
  3:          0  SiFive PLIC   2 Edge      virtio0
  5:      58985  RISC-V INTC   5 Edge      riscv-timer
...
  1:        610  SiFive PLIC   1 Edge      ttyS0
  2:         19  SiFive PLIC   3 Edge      virtio1
  3:          0  SiFive PLIC   2 Edge      virtio0
  5:      59196  RISC-V INTC   5 Edge      riscv-timer
...
  1:        625  SiFive PLIC   1 Edge      ttyS0
  2:         19  SiFive PLIC   3 Edge      virtio1
  3:          0  SiFive PLIC   2 Edge      virtio0
  5:      59296  RISC-V INTC   5 Edge      riscv-timer
```