### PR TITLE
Fix incompatible mmu-type

### DIFF
--- a/minimal.dts
+++ b/minimal.dts
@@ -25,7 +25,7 @@
             compatible = "riscv";
             reg = <0>;
             riscv,isa = "rv32ima";
-            mmu-type = "riscv,rv32";
+            mmu-type = "riscv,sv32";
             cpu0_intc: interrupt-controller {
                 #interrupt-cells = <1>;
                 #address-cells = <0>;


### PR DESCRIPTION
Per https://github.com/riscv-non-isa/riscv-device-tree-doc/blob/master/bindings/riscv/cpus.txt , the `mmu-type` attribute should be set to "riscv,sv32"