### PR TITLE
Replace mtime counter with realtime timer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ CC ?= gcc
 CFLAGS := -O2 -g -Wall -Wextra
 CFLAGS += -include common.h
 
+# clock frequency
+CLOCK_FREQ ?= 65000000
+DT_CFLAGS := -D CLOCK_FREQ=$(CLOCK_FREQ)
+CFLAGS += $(DT_CFLAGS)
+
 OBJS_EXTRA :=
 # command line option
 OPTS :=
@@ -42,6 +47,7 @@ all: $(BIN) minimal.dtb
 OBJS := \
 	riscv.o \
 	ram.o \
+	utils.o \
 	plic.o \
 	uart.o \
 	main.o \
@@ -72,11 +78,12 @@ S := $E $E
 SMP ?= 1
 .PHONY: riscv-harts.dtsi
 riscv-harts.dtsi:
-	$(Q)python3 scripts/gen-hart-dts.py $@ $(SMP)
+	$(Q)python3 scripts/gen-hart-dts.py $@ $(SMP) $(CLOCK_FREQ)
 
 minimal.dtb: minimal.dts riscv-harts.dtsi
 	$(VECHO) " DTC\t$@\n"
 	$(Q)$(CC) -nostdinc -E -P -x assembler-with-cpp -undef \
+	    $(DT_CFLAGS) \
 	    $(subst ^,$S,$(filter -D^SEMU_FEATURE_%, $(subst -D$(S)SEMU_FEATURE,-D^SEMU_FEATURE,$(CFLAGS)))) $< \
 	    | $(DTC) - > $@
 

--- a/device.h
+++ b/device.h
@@ -175,7 +175,7 @@ uint32_t *virtio_blk_init(virtio_blk_state_t *vblk, char *disk_file);
 typedef struct {
     uint32_t msip[4096];
     uint64_t mtimecmp[4095];
-    uint64_t mtime;
+    semu_timer_t mtime;
 } clint_state_t;
 
 void clint_update_interrupts(hart_t *vm, clint_state_t *clint);

--- a/minimal.dts
+++ b/minimal.dts
@@ -24,7 +24,7 @@
     cpus {
         #address-cells = <1>;
         #size-cells = <0>;
-        timebase-frequency = <65000000>;
+        timebase-frequency = <CLOCK_FREQ>;
     };
 
     sram: memory@0 {

--- a/riscv.c
+++ b/riscv.c
@@ -434,10 +434,10 @@ static void csr_read(hart_t *vm, uint16_t addr, uint32_t *value)
 {
     switch (addr) {
     case RV_CSR_TIME:
-        *value = vm->time;
+        *value = semu_timer_get(&vm->time);
         return;
     case RV_CSR_TIMEH:
-        *value = vm->time >> 32;
+        *value = semu_timer_get(&vm->time) >> 32;
         return;
     case RV_CSR_INSTRET:
         *value = vm->instret;

--- a/riscv.h
+++ b/riscv.h
@@ -3,6 +3,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "utils.h"
+
 /* ERR_EXCEPTION indicates that the instruction has raised one of the
  * exceptions defined in the specification. If this flag is set, the
  * additional fields "exc_cause" and "exc_val" must also be set to values
@@ -70,8 +72,7 @@ struct __hart_internal {
      * resets.
      */
     uint64_t instret;
-    uint64_t time;
-
+    semu_timer_t time;
     /* Instruction execution state must be set to "NONE" for instruction
      * execution to continue. If the state is not "NONE," the vm_step()
      * function will exit.

--- a/scripts/gen-hart-dts.py
+++ b/scripts/gen-hart-dts.py
@@ -34,12 +34,12 @@ def clint_irq_format(nums):
         s += f"<&cpu{i}_intc 3 &cpu{i}_intc 7>, "
     return s[:-2]
 
-def dtsi_template (cpu_list: str, plic_list, clint_list):
+def dtsi_template (cpu_list: str, plic_list, clint_list, clock_freq):
     return f"""/{{
     cpus {{
         #address-cells = <1>;
         #size-cells = <0>;
-        timebase-frequency = <65000000>;
+        timebase-frequency = <{clock_freq}>;
         {cpu_list}
     }};
 
@@ -67,6 +67,7 @@ def dtsi_template (cpu_list: str, plic_list, clint_list):
 
 dtsi = sys.argv[1]
 harts = int(sys.argv[2])
+clock_freq = int(sys.argv[3])
 
 with open(dtsi, "w") as dts:
-    dts.write(dtsi_template(cpu_format(harts), plic_irq_format(harts), clint_irq_format(harts)))
+    dts.write(dtsi_template(cpu_format(harts), plic_irq_format(harts), clint_irq_format(harts), clock_freq))

--- a/utils.c
+++ b/utils.c
@@ -1,0 +1,52 @@
+#include <time.h>
+
+#include "utils.h"
+
+#if defined(__APPLE__)
+#define HAVE_MACH_TIMER
+#include <mach/mach_time.h>
+#elif !defined(_WIN32) && !defined(_WIN64)
+#define HAVE_POSIX_TIMER
+
+/*
+ * Use a faster but less precise clock source because we need quick
+ * timestamps rather than fine-grained precision.
+ */
+#ifdef CLOCK_MONOTONIC_COARSE
+#define CLOCKID CLOCK_MONOTONIC_COARSE
+#else
+#define CLOCKID CLOCK_REALTIME_COARSE
+#endif
+#endif
+
+void semu_timer_init(semu_timer_t *timer, uint64_t freq)
+{
+    timer->freq = freq;
+    semu_timer_rebase(timer, 0);
+}
+
+static uint64_t semu_timer_clocksource(uint64_t freq)
+{
+#if defined(HAVE_POSIX_TIMER)
+    struct timespec t;
+    clock_gettime(CLOCKID, &t);
+    return (t.tv_sec * freq) + (t.tv_nsec * freq / 1e9);
+#elif defined(HAVE_MACH_TIMER)
+    static mach_timebase_info_data_t t;
+    if (mach_clk.denom == 0)
+        (void) mach_timebase_info(&t);
+    return mach_absolute_time() * freq / t.denom * t.numer;
+#else
+    return time(0) * freq;
+#endif
+}
+
+uint64_t semu_timer_get(semu_timer_t *timer)
+{
+    return semu_timer_clocksource(timer->freq) - timer->begin;
+}
+
+void semu_timer_rebase(semu_timer_t *timer, uint64_t time)
+{
+    timer->begin = semu_timer_clocksource(timer->freq) - time;
+}

--- a/utils.h
+++ b/utils.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <stdint.h>
+
+/* TIMER */
+typedef struct {
+    uint64_t begin;
+    uint64_t freq;
+} semu_timer_t;
+
+void semu_timer_init(semu_timer_t *timer, uint64_t freq);
+uint64_t semu_timer_get(semu_timer_t *timer);
+void semu_timer_rebase(semu_timer_t *timer, uint64_t time);


### PR DESCRIPTION
Replace `mtime` counter by retrieving time of the specified clock ID. Also, Real time counter (RTC) mechanism is implemented to prevent `mtime` overflow.

Before:
```
[    0.000000] Linux version 6.1.94 (aaron@aaron-Lenovo-Y520-15IKBN) (riscv32-buildroot-linux-gnu-gcc.br_real (Buildroot 2024.02.3) 12.3.0, GNU ld (GNU Binutils) 2.41) #8 SMP Thu Jul 11 00:37:05 CST 2024
[    0.000000] Machine model: semu
[    0.000000] earlycon: ns16550 at MMIO 0xf4000000 (options '')
[    0.000000] printk: bootconsole [ns16550] enabled
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x000000001fffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
...
[    2.687661] Freeing initrd memory: 8188K
[    2.691697] Freeing unused kernel image (initmem) memory: 180K
[    2.691978] Kernel memory protection not selected by kernel config.
[    2.692277] Run /init as init process

```
Now:
```
[    0.000000] Linux version 6.1.94 (aaron@aaron-Lenovo-Y520-15IKBN) (riscv32-buildroot-linux-gnu-gcc.br_real (Buildroot 2024.02.3) 12.3.0, GNU ld (GNU Binutils) 2.41) #10 SMP Mon Jul 15 02:47:57 CST 2024
[    0.000000] Machine model: semu
[    0.000000] earlycon: ns16550 at MMIO 0xf4000000 (options '')
[    0.000000] printk: bootconsole [ns16550] enabled
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x000000001fffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
...
[   73.908933] Freeing initrd memory: 8188K
[   74.033405] Freeing unused kernel image (initmem) memory: 180K
[   74.044397] Kernel memory protection not selected by kernel config.
[   74.064088] Run /init as init process
```
Revised boot log to display actual timer during boot flow.

Reference to RVVM:https://github.com/LekKit/RVVM/blob/staging/src/rvtimer.c

However, another issue accopanies this PR
```
[   32.038173] rcu: INFO: rcu_sched self-detected stall on CPU
[   32.043867] rcu: 	3-....: (5248 ticks this GP) idle=846c/1/0x40000002 softirq=371/371 fqs=2114
[   32.055848] 	(t=5251 jiffies g=-883 q=10 ncpus=4)
[   32.064761] CPU: 3 PID: 39 Comm: kworker/u8:1 Not tainted 6.1.94 #10
```
RCU issues a CPU stall wrning when it waits more than a grace period, which is normally 21 seconds.

Detail here: https://docs.kernel.org/RCU/stallwarn.html