### PR TITLE
Fix clint node in DTS by removing interrupt-controller property

### DIFF
--- a/scripts/gen-hart-dts.py
+++ b/scripts/gen-hart-dts.py
@@ -56,7 +56,6 @@ def dtsi_template (cpu_list: str, plic_list, clint_list, clock_freq):
 
         clint0: clint@4300000 {{
             compatible = "riscv,clint0";
-            interrupt-controller;
             interrupts-extended =
             {clint_list};
             reg = <0x4300000 0x10000>;


### PR DESCRIPTION
Fix the device tree configuration by removing the interrupt-controller property from the clint node. The clint only handles timer and software interrupts, and should not be configured as an interrupt controller. Only the plic should be marked as an interrupt-controller as it manages external interrupts.

This change resolves the following dtc warnings about missing proper configuration of interrupt handling:

<stdin>:31.31-37.11: Warning (interrupt_provider): /soc@F0000000/clint@4300000: Missing #interrupt-cells in interrupt provider
<stdin>:31.31-37.11: Warning (interrupt_provider): /soc@F0000000/clint@4300000: Missing #address-cells in interrupt provider