### PR TITLE
Fix build on macOS

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -46,7 +46,7 @@ static uint64_t semu_timer_clocksource(uint64_t freq)
     return t.tv_sec * freq + mult_frac(t.tv_nsec, freq, 1e9);
 #elif defined(HAVE_MACH_TIMER)
     static mach_timebase_info_data_t t;
-    if (mach_clk.denom == 0)
+    if (t.denom == 0)
         (void) mach_timebase_info(&t);
     return mult_frac(mach_absolute_time() * freq, t.numer, t.denom);
 #else


### PR DESCRIPTION
utils.c:49:9: error: use of undeclared identifier 'mach_clk'