### PR TITLE
Fix incorrect clock calculation on macOS

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -48,7 +48,8 @@ static uint64_t semu_timer_clocksource(uint64_t freq)
     static mach_timebase_info_data_t t;
     if (t.denom == 0)
         (void) mach_timebase_info(&t);
-    return mult_frac(mach_absolute_time() * freq, t.numer, t.denom);
+    return mult_frac(mult_frac(mach_absolute_time(), freq, 1e9), t.numer,
+                     t.denom);
 #else
     return time(0) * freq;
 #endif


### PR DESCRIPTION
The current `semu_timer_clocksource()` returns the clock source in nanoseconds when building on macOS. Causing an abnormal timestamp in the boot log.
```
...
[ 3062.927108] sched_clock: 64 bits at 65MHz, resolution 15ns, wraps every 2199023255550ns
```
Divide the return value by 1e9, ensuring the clock source is provided in seconds.


