### PR TITLE
Optimize semu_timer_clocksource() precision on macOS

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -48,8 +48,8 @@ static uint64_t semu_timer_clocksource(uint64_t freq)
     static mach_timebase_info_data_t t;
     if (t.denom == 0)
         (void) mach_timebase_info(&t);
-    return mult_frac(mult_frac(mach_absolute_time(), freq, 1e9), t.numer,
-                     t.denom);
+    return mult_frac(mult_frac(mach_absolute_time(), t.numer, t.denom), freq,
+                     1e9);
 #else
     return time(0) * freq;
 #endif


### PR DESCRIPTION
Improve the precision of semu_timer_clocksource() by deferring the division by 1e9 until the final step. Since t.numer and t.denom are typically much smaller compared to the clock frequency and 1e9, performing the division earlier in the calculation could result in a significant loss of precision. This change ensures that precision is preserved by delaying the division until the end of the computation.