### PR TITLE
Bump Buildroot to the 2024.11.1 release

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -21,7 +21,7 @@ PARALLEL="-j$(nproc)"
 
 function do_buildroot
 {
-    ASSERT git clone https://github.com/buildroot/buildroot -b 2024.05.2 --depth=1
+    ASSERT git clone https://github.com/buildroot/buildroot -b 2024.11.1 --depth=1
     cp -f configs/buildroot.config buildroot/.config
     cp -f configs/busybox.config buildroot/busybox.config
     # Otherwise, the error below raises:


### PR DESCRIPTION
The GCC 14 now enforces a stricter error level by treating the `-Wimplicit-int` warning as an error by default. This change causes a compilation issue with the [libsha1](https://github.com/dottedmag/libsha1) library, which is necessary for enabling the X.Org Server.

Upgrading to Buildroot version [2024.11.1](https://github.com/buildroot/buildroot/releases/tag/2024.11.1) resolves this issue, as it includes a patch [1] that addresses the problem.

[1] [0001-test-fix-gcc-14.x-compile-implicit-int.patch](https://github.com/buildroot/buildroot/blob/65137580ca9ed060c59544b9859fc648e902c694/package/libsha1/0001-test-fix-gcc-14.x-compile-implicit-int.patch)