### PR TITLE
Rectify length of Virtio descriptor address

### DIFF
--- a/virtio-blk.c
+++ b/virtio-blk.c
@@ -102,7 +102,7 @@ static void virtio_blk_update_status(virtio_blk_state_t *vblk, uint32_t status)
 
 static void virtio_blk_write_handler(virtio_blk_state_t *vblk,
                                      uint64_t sector,
-                                     uint32_t desc_addr,
+                                     uint64_t desc_addr,
                                      uint32_t len)
 {
     void *dest = (void *) ((uintptr_t) vblk->disk + sector * DISK_BLK_SIZE);
@@ -112,7 +112,7 @@ static void virtio_blk_write_handler(virtio_blk_state_t *vblk,
 
 static void virtio_blk_read_handler(virtio_blk_state_t *vblk,
                                     uint64_t sector,
-                                    uint32_t desc_addr,
+                                    uint64_t desc_addr,
                                     uint32_t len)
 {
     void *dest = (void *) ((uintptr_t) vblk->ram + desc_addr);
@@ -141,13 +141,15 @@ static int virtio_blk_desc_handler(virtio_blk_state_t *vblk,
     /* Collect the descriptors */
     for (int i = 0; i < 3; i++) {
         /* The size of the `struct virtq_desc` is 4 words */
-        const uint32_t *desc = &vblk->ram[queue->QueueDesc + desc_idx * 4];
+        const struct virtq_desc *desc =
+            (struct virtq_desc *) &vblk->ram[queue->QueueDesc + desc_idx * 4];
+
 
         /* Retrieve the fields of current descriptor */
-        vq_desc[i].addr = desc[0];
-        vq_desc[i].len = desc[2];
-        vq_desc[i].flags = desc[3];
-        desc_idx = desc[3] >> 16; /* vq_desc[desc_cnt].next */
+        vq_desc[i].addr = desc->addr;
+        vq_desc[i].len = desc->len;
+        vq_desc[i].flags = desc->flags;
+        desc_idx = desc->next;
     }
 
     /* The next flag for the first and second descriptors should be set,

--- a/virtio-rng.c
+++ b/virtio-rng.c
@@ -61,20 +61,16 @@ static void virtio_queue_notify_handler(virtio_rng_state_t *vrng,
     VRNG_QUEUE.last_avail++;
 
     /* Read descriptor */
-    uint32_t *desc = &vrng->ram[queue->QueueDesc + buffer_idx * 4];
-    struct virtq_desc vq_desc = {
-        .addr = desc[0],
-        .len = desc[2],
-        .flags = desc[3],
-    };
+    struct virtq_desc *vq_desc =
+        (struct virtq_desc *) &vrng->ram[queue->QueueDesc + buffer_idx * 4];
 
     /* Write entropy buffer */
     void *entropy_buf =
-        (void *) ((uintptr_t) vrng->ram + (uintptr_t) vq_desc.addr);
-    ssize_t total = read(rng_fd, entropy_buf, vq_desc.len);
+        (void *) ((uintptr_t) vrng->ram + (uintptr_t) vq_desc->addr);
+    ssize_t total = read(rng_fd, entropy_buf, vq_desc->len);
 
     /* Clear write flag */
-    desc[3] = 0;
+    vq_desc->flags = 0;
 
     /* Get virtq_used.idx (le16) */
     uint16_t used = ram[queue->QueueUsed] >> 16;

--- a/virtio.h
+++ b/virtio.h
@@ -57,9 +57,9 @@ enum {
 #undef _
 };
 
-struct virtq_desc {
-    uint32_t addr;
+PACKED(struct virtq_desc {
+    uint64_t addr;
     uint32_t len;
     uint16_t flags;
     uint16_t next;
-};
+});


### PR DESCRIPTION
According to Virtio Specification Version 1.3, Section 2.7.5 *The Virtqueue Descriptor Table*, the type of `addr` should be `uint64_t` instead of `uint32_t`.
This commit addresses the error in the previous implementation.