### PR TITLE
Support GDB stub for remote debugging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
     path = cnfa
     url = https://github.com/cntools/cnfa
     shallow = true
+[submodule "mini-gdbstub"]
+    path = mini-gdbstub
+    url = https://github.com/RinHizakura/mini-gdbstub
+    shallow = true

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,14 @@ OBJS := \
 
 deps := $(OBJS:%.o=.%.o.d)
 
+GDBSTUB_LIB := mini-gdbstub/build/libgdbstub.a
+LDFLAGS += $(GDBSTUB_LIB)
+mini-gdbstub/Makefile:
+	git submodule update --init $(dir $@)
+$(GDBSTUB_LIB): mini-gdbstub/Makefile
+	$(MAKE) -C $(dir $<)
+$(OBJS): $(GDBSTUB_LIB)
+
 $(BIN): $(OBJS)
 	$(VECHO) "  LD\t$@\n"
 	$(Q)$(CC) -o $@ $^ $(LDFLAGS)
@@ -152,6 +160,7 @@ build-image:
 
 clean:
 	$(Q)$(RM) $(BIN) $(OBJS) $(deps)
+	$(Q)$(MAKE) -C mini-gdbstub clean
 
 distclean: clean
 	$(Q)$(RM) riscv-harts.dtsi

--- a/device.h
+++ b/device.h
@@ -355,9 +355,11 @@ bool virtio_snd_init(virtio_snd_state_t *vsnd);
 
 /* memory mapping */
 typedef struct {
+    bool debug;
     bool stopped;
     uint32_t *ram;
     uint32_t *disk;
+    vm_t vm;
     plic_state_t plic;
     u8250_state_t uart;
 #if SEMU_HAS(VIRTIONET)
@@ -376,4 +378,10 @@ typedef struct {
 #if SEMU_HAS(VIRTIOSND)
     virtio_snd_state_t vsnd;
 #endif
+
+    uint32_t peripheral_update_ctr;
+
+    /* The fields used for debug mode */
+    bool is_interrupted;
+    int curr_cpuid;
 } emu_state_t;


### PR DESCRIPTION
Enable the emulator to act as gdbstub. This feature helps to dignose and debug issue of emulator more simply. 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements GDB remote debugging functionality by integrating mini-gdbstub library, adding debug mode with -g option, and restructuring the main emulation loop. The changes enable the emulator to function as a GDB remote target on port 1234, supporting interactive debugging through register/memory access and execution control features.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 4
</div>