### PR TITLE
Initialize harts with zero properly

### DIFF
--- a/main.c
+++ b/main.c
@@ -650,7 +650,11 @@ static int semu_init(emu_state_t *emu, int argc, char **argv)
     vm->n_hart = hart_count;
     vm->hart = malloc(sizeof(hart_t *) * vm->n_hart);
     for (uint32_t i = 0; i < vm->n_hart; i++) {
-        hart_t *newhart = malloc(sizeof(hart_t));
+        hart_t *newhart = calloc(1, sizeof(hart_t));
+        if (!newhart) {
+            fprintf(stderr, "Failed to allocate hart #%u.\n", i);
+            return 1;
+        }
         INIT_HART(newhart, emu, i);
         newhart->x_regs[RV_R_A0] = i;
         newhart->x_regs[RV_R_A1] = dtb_addr;


### PR DESCRIPTION
Uninitialized hart_t fields may lead to undefined behavior or startup exceptions. This change replaces malloc with calloc to ensure that all fields are zeroed upon allocation, providing a safer and more consistent initialization.

Closed : #69  
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the safety of hart_t instance initialization by replacing malloc with calloc, ensuring all fields are zero-initialized upon allocation. This change addresses potential undefined behavior and improves consistency.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on memory allocation safety, making the review process relatively simple.
</div>