### PR TITLE
Enable user-mode networking through SLIRP

### DIFF
--- a/.ci/test-netdev.sh
+++ b/.ci/test-netdev.sh
@@ -45,10 +45,13 @@ ASSERT expect <<DONE
         expect "riscv32 GNU/Linux" { send "ip l set eth0 up\n" } timeout { exit 3 }
         expect "# " { send "ip a add 192.168.10.2/24 dev eth0\n" }
         expect "# " { send "ping -c 3 192.168.10.1\n" }
-        expect "3 packets transmitted, 3 packets received, 0% packet loss" { } timeout { exit 4 }    
+        expect "3 packets transmitted, 3 packets received, 0% packet loss" { } timeout { exit 4 }
     } elseif { "$NETDEV" == "user" } {
-        # Test slirp configuration
-        expect "riscv32 GNU/Linux" { send "\x01"; send "x" } timeout { exit 3 }
+        expect "riscv32 GNU/Linux" { send "ip addr add 10.0.2.15/24 dev eth0\n" } timeout { exit 3 }
+        expect "# " { send "ip link set eth0 up\n"}
+        expect "# " { send "ip route add default via 10.0.2.2\n"}
+        expect "# " { send "ping -c 3 10.0.2.2\n" }
+        expect "3 packets transmitted, 3 packets received, 0% packet loss" { } timeout { exit 4 }
     }
 DONE
 }

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
     path = mini-gdbstub
     url = https://github.com/RinHizakura/mini-gdbstub
     shallow = true
+[submodule "minislirp"]
+	path = minislirp
+	url = https://github.com/edubart/minislirp
+    shallow = true

--- a/device.h
+++ b/device.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#if SEMU_HAS(VIRTIONET)
 #include "netdev.h"
+#endif
 #include "riscv.h"
 #include "virtio.h"
 
@@ -119,6 +121,8 @@ void virtio_net_write(hart_t *core,
                       uint8_t width,
                       uint32_t value);
 void virtio_net_refresh_queue(virtio_net_state_t *vnet);
+
+void virtio_net_recv_from_peer(void *peer);
 
 bool virtio_net_init(virtio_net_state_t *vnet, const char *name);
 #endif /* SEMU_HAS(VIRTIONET) */

--- a/netdev.h
+++ b/netdev.h
@@ -1,6 +1,11 @@
 #pragma once
 
-#include <stdbool.h>
+#include <poll.h>
+#include <unistd.h>
+
+#include "minislirp/src/libslirp.h"
+#include "utils.h"
+
 
 /* clang-format off */
 #define SUPPORTED_DEVICES   \
@@ -18,9 +23,33 @@ typedef struct {
     int tap_fd;
 } net_tap_options_t;
 
+/* SLIRP */
+#define SLIRP_POLL_INTERVAL 100000
+#define SLIRP_READ_SIDE 0
+#define SLIRP_WRITE_SIDE 1
 typedef struct {
-    /* TODO: Implement user option */
+    semu_timer_t timer;
+    Slirp *slirp;
+    SlirpTimerId id;
+    void *cb_opaque;
+    void (*cb)(void *opaque);
+    int64_t expire_timer_msec;
+} slirp_timer;
+
+typedef struct {
+    Slirp *slirp;
+    int channel[2];
+    int pfd_len;
+    int pfd_size;
+    struct pollfd *pfd;
+    slirp_timer *timer;
+    void *peer;
 } net_user_options_t;
+
+Slirp *slirp_create(net_user_options_t *usr, SlirpConfig *cfg);
+int net_slirp_init(net_user_options_t *usr);
+int semu_slirp_add_poll_socket(slirp_os_socket fd, int events, void *opaque);
+int semu_slirp_get_revents(int idx, void *opaque);
 
 typedef struct {
     char *name;

--- a/slirp.c
+++ b/slirp.c
@@ -1,0 +1,205 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "netdev.h"
+
+/* Slirp callback: invoked when Slirp wants to send a packet to the backend */
+static ssize_t net_slirp_send_packet(const void *buf, size_t len, void *opaque)
+{
+    net_user_options_t *usr = (net_user_options_t *) opaque;
+
+    return write(usr->channel[SLIRP_WRITE_SIDE], buf, len);
+}
+
+/* Slirp callback: reports an error from the guest (current unused) */
+static void net_slirp_guest_error(const char *msg UNUSED, void *opaque UNUSED)
+{
+    // Unused
+}
+
+/* Slirp callback: returns current time in nanoseconds for Slirp timers */
+static int64_t net_slirp_clock_get_ns(void *opaque UNUSED)
+{
+    net_user_options_t *usr = (net_user_options_t *) opaque;
+
+    return semu_timer_get(&usr->timer->timer);
+}
+
+/* Slirp callback: called when Slirp has finished initialization */
+static void net_slirp_init_completed(Slirp *slirp, void *opaque)
+{
+    net_user_options_t *s = opaque;
+    s->slirp = slirp;
+}
+
+static void slirp_timer_init(slirp_timer *t, void (*cb)(void *opaque))
+{
+    t->cb = cb;
+    semu_timer_init(&t->timer, CLOCK_FREQ, 1);
+}
+
+static void net_slirp_timer_cb(void *opaque)
+{
+    slirp_timer *t = opaque;
+    slirp_handle_timer(t->slirp, t->id, t->cb_opaque);
+}
+
+/* Slirp callback: allocated and initializes a new timer object */
+static void *net_slirp_timer_new_opaque(SlirpTimerId id,
+                                        void *cb_opaque,
+                                        void *opaque)
+{
+    net_user_options_t *usr = (net_user_options_t *) opaque;
+    slirp_timer *t = malloc(sizeof(slirp_timer));
+    usr->timer = t;
+    t->slirp = usr->slirp;
+    t->id = id;
+    t->cb_opaque = cb_opaque;
+    t->expire_timer_msec = -1;
+    slirp_timer_init(t, net_slirp_timer_cb);
+
+    return t;
+}
+
+/* Slirp callback: releases resources associated with a timer */
+static void net_slirp_timer_free(void *timer, void *opaque UNUSED)
+{
+    if (timer)
+        free(timer);
+}
+
+/* Slirp callback: modifies the expiration time of an existing timer */
+static void net_slirp_timer_mod(void *timer,
+                                int64_t expire_time,
+                                void *opaque UNUSED)
+{
+    slirp_timer *t = (slirp_timer *) timer;
+    semu_timer_rebase(&t->timer, expire_time);
+}
+
+/* Slirp callback: registers a pollable socket (unused in this backend) */
+static void net_slirp_register_poll_sock(int fd UNUSED, void *opaque UNUSED)
+{
+    // Unused
+}
+
+/* Slirp callback: unregisters a pollable socket (unused in this backend) */
+static void net_slirp_unregister_poll_sock(int fd UNUSED, void *opaque UNUSED)
+{
+    // Unused
+}
+
+/* Slirp callback: notifies backend of pending activity (unused) */
+static void net_slirp_notify(void *opaque UNUSED)
+{
+    // Unused
+}
+
+static const SlirpCb slirp_cb = {
+    .send_packet = net_slirp_send_packet,
+    .guest_error = net_slirp_guest_error,
+    .clock_get_ns = net_slirp_clock_get_ns,
+    .init_completed = net_slirp_init_completed,
+    .timer_new_opaque = net_slirp_timer_new_opaque,
+    .timer_free = net_slirp_timer_free,
+    .timer_mod = net_slirp_timer_mod,
+    .register_poll_socket = net_slirp_register_poll_sock,
+    .unregister_poll_socket = net_slirp_unregister_poll_sock,
+    .notify = net_slirp_notify,
+};
+
+static int poll_to_slirp_poll(int events)
+{
+    int ret = 0;
+    if (events & POLLIN)
+        ret |= SLIRP_POLL_IN;
+    if (events & POLLOUT)
+        ret |= SLIRP_POLL_OUT;
+    if (events & POLLPRI)
+        ret |= SLIRP_POLL_PRI;
+    if (events & POLLERR)
+        ret |= SLIRP_POLL_ERR;
+    if (events & POLLHUP)
+        ret |= SLIRP_POLL_HUP;
+    return ret;
+}
+
+int semu_slirp_get_revents(int idx, void *opaque)
+{
+    net_user_options_t *usr = opaque;
+    return poll_to_slirp_poll(usr->pfd[idx].revents);
+}
+
+int semu_slirp_add_poll_socket(slirp_os_socket fd, int events, void *opaque)
+{
+    net_user_options_t *usr = opaque;
+    if (usr->pfd_len >= usr->pfd_size) {
+        int newsize = usr->pfd_size + 16;
+        struct pollfd *new = realloc(usr->pfd, newsize * sizeof(struct pollfd));
+        if (new) {
+            usr->pfd = new;
+            usr->pfd_size = newsize;
+        }
+    }
+    if (usr->pfd_len < usr->pfd_size) {
+        int idx = usr->pfd_len++;
+        usr->pfd[idx].fd = fd;
+
+        usr->pfd[idx].events = poll_to_slirp_poll(events);
+        return idx;
+    } else {
+        return -1;
+    }
+}
+
+Slirp *slirp_create(net_user_options_t *usr, SlirpConfig *cfg)
+{
+    /* Create a Slirp instance with special address. All
+     * addresses of the form 10.0.2.xxx are special to
+     * Slirp.
+     */
+    cfg->version = SLIRP_CHECK_VERSION(4, 8, 0)   ? 6
+                   : SLIRP_CHECK_VERSION(4, 7, 0) ? 4
+                                                  : 1;
+    cfg->restricted = 0;
+    cfg->in_enabled = 1;
+    inet_pton(AF_INET, "10.0.2.0", &(cfg->vnetwork));
+    inet_pton(AF_INET, "255.255.255.0", &(cfg->vnetmask));
+    inet_pton(AF_INET, "10.0.2.2", &(cfg->vhost));
+    cfg->in6_enabled = 1;
+    inet_pton(AF_INET6, "fd00::", &cfg->vprefix_addr6);
+    cfg->vhostname = "slirp";
+    cfg->tftp_server_name = NULL;
+    cfg->tftp_path = NULL;
+    cfg->bootfile = NULL;
+    inet_pton(AF_INET, "10.0.2.15", &(cfg->vdhcp_start));
+    inet_pton(AF_INET, "10.0.2.3", &(cfg->vnameserver));
+    inet_pton(AF_INET6, "fd00::3", &cfg->vnameserver6);
+    cfg->vdnssearch = NULL;
+    cfg->vdomainname = NULL;
+    cfg->if_mtu = 1500;
+    cfg->if_mru = 1500;
+    cfg->outbound_addr = NULL;
+    cfg->disable_host_loopback = 0;
+
+    return slirp_new(cfg, &slirp_cb, usr);
+}
+
+int net_slirp_init(net_user_options_t *usr)
+{
+    SlirpConfig cfg;
+    usr->slirp = slirp_create(usr, &cfg);
+    if (usr->slirp == NULL) {
+        fprintf(stderr, "create slirp failed\n");
+    }
+
+    usr->pfd = malloc(sizeof(struct pollfd));
+
+    /* Register the read end of the internal pipe (channel[SLIRP_READ_SIDE])
+     * with slirp's poll system. This allows slirp to monitor it for incoming
+     * data (POLL_IN) or hang-up event (POLL_HUP).
+     */
+    semu_slirp_add_poll_socket(usr->channel[SLIRP_READ_SIDE],
+                               SLIRP_POLL_IN | SLIRP_POLL_HUP, usr);
+    return 0;
+}


### PR DESCRIPTION
This commit integrates 'minislirp' as submodule and enables support for the new 'user' network device, which uses SLIRP for user-mode networking.

An internal pipe mechanism is introduced to monitor incoming data. The main loop polls the pipe for availabe data, and any incoming data is forwarded to the virtio-net device for processing.

Additionally, this commit introduces special address used by SLIRP for network configuration [1]:
- **10.0.2.0**: The SLIRP "on-line" configuration address.
- **10.0.2.2**: An alias for the host running SLIRP.
- **10.0.2.3**: An alias for the DNS address.
- **10.0.2.15**: A recommended address for the PC running SLIRP.

### Test procedures
1. Laumch `semu` with specified NETDEV=user
```
cd semu/
make check NETDEV=user
```
2. Configure the network interface with an IP address and routing:
```
ip addr add 10.0.2.15/24 dev eth0
ip link set eth0 up
ip route add default via 10.0.2.2
```
3. Test nerwork connectivity by pinging an external address:
```
# ping -c 3 8.8.8.8
PING 8.8.8.8 (8.8.8.8): 56 data bytes
```
4. Output
```
64 bytes from 8.8.8.8: seq=0 ttl=255 time=17.001 ms
64 bytes from 8.8.8.8: seq=1 ttl=255 time=20.001 ms
64 bytes from 8.8.8.8: seq=2 ttl=255 time=17.001 ms

--- 8.8.8.8 ping statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 17.001/18.001/20.001 ms
```



- [ ] MacOS CI Flow issue: Currently, the MacOs CI flow is failing. The issue may be releated to a redefined `swab` function, similar to the one discussed in https://github.com/86Box/86Box/issues/136

[1]: https://github.com/kost/slirp/blob/master/docs/slirp.doc