### PR TITLE
Support mounting rootfs from virtio-blk via initrd

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,54 @@ You can exit the emulator using: \<Ctrl-a x\>. (press Ctrl+A, leave it, afterwar
 An automated build script is provided to compile the RISC-V cross-compiler, Busybox, and Linux kernel from source.
 Please note that it only supports the Linux host environment.
 
+To build everything, simply run:
+
 ```shell
 $ make build-image
+```
+
+This command invokes the underlying script: `scripts/build-image.sh`, which also offers more flexible usage options.
+
+### Script Usage
+
+```
+./scripts/build-image.sh [--buildroot] [--linux] [--all] [--external-root] [--clean-build] [--help]
+
+Options:
+  --buildroot         Build Buildroot rootfs
+  --linux             Build Linux kernel
+  --all               Build both Buildroot and Linux
+  --external-root     Use external rootfs instead of initramfs
+  --clean-build       Remove entire buildroot/ and/or linux/ directories before build
+  --help              Show this message
+```
+
+### Examples
+
+Build the Linux kernel only:
+
+```
+$ scripts/build-image.sh --linux
+```
+
+Build Buildroot only:
+
+```
+$ scripts/build-image.sh --buildroot
+```
+
+Build Buildroot and generate an external root file system (ext4 image):
+
+```
+$ scripts/build-image.sh --buildroot --external-root
+```
+
+Force a clean build:
+
+```
+$ scripts/build-image.sh --all --clean-build
+$ scripts/build-image.sh --linux --clean-build
+$ scripts/build-image.sh --buildroot --clean-build
 ```
 
 ## License

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -19,11 +19,31 @@ function OK
 
 PARALLEL="-j$(nproc)"
 
+function safe_copy {
+    local src="$1"
+    local dst="$2"
+
+    if [ ! -f "$dst" ]; then
+        echo "Copying $src -> $dst"
+        cp -f "$src" "$dst"
+    else
+        echo "$dst already exists, skipping copy"
+    fi
+}
+
 function do_buildroot
 {
-    ASSERT git clone https://github.com/buildroot/buildroot -b 2024.11.1 --depth=1
-    cp -f configs/buildroot.config buildroot/.config
-    cp -f configs/busybox.config buildroot/busybox.config
+    if [ ! -d buildroot ]; then
+        echo "Cloning Buildroot..."
+        ASSERT git clone https://github.com/buildroot/buildroot -b 2024.11.1 --depth=1
+    else
+        echo "buildroot/ already exists, skipping clone"
+    fi
+
+    safe_copy configs/buildroot.config buildroot/.config
+    safe_copy configs/busybox.config buildroot/busybox.config
+    cp -f target/init buildroot/fs/cpio/init
+    
     # Otherwise, the error below raises:
     #   You seem to have the current working directory in your
     #   LD_LIBRARY_PATH environment variable. This doesn't work.
@@ -32,13 +52,28 @@ function do_buildroot
     ASSERT make olddefconfig
     ASSERT make $PARALLEL
     popd
-    cp -f buildroot/output/images/rootfs.cpio ./
+
+    if [[ $EXTERNAL_ROOT -eq 1 ]]; then
+        echo "Copying rootfs.cpio to rootfs_full.cpio (external root mode)"
+        cp -f buildroot/output/images/rootfs.cpio ./rootfs_full.cpio
+        ASSERT ./scripts/rootfs_ext4.sh
+    else
+        echo "Copying rootfs.cpio to rootfs.cpio (initramfs mode)"
+        cp -f buildroot/output/images/rootfs.cpio ./rootfs.cpio
+    fi
 }
 
 function do_linux
 {
-    ASSERT git clone https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git -b linux-6.12.y --depth=1
-    cp -f configs/linux.config linux/.config
+    if [ ! -d linux ]; then
+        echo "Cloning Linux kernel..."
+        ASSERT git clone https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git -b linux-6.12.y --depth=1
+    else
+        echo "linux/ already exists, skipping clone"
+    fi
+
+    safe_copy configs/linux.config linux/.config
+
     export PATH="$PWD/buildroot/output/host/bin:$PATH"
     export CROSS_COMPILE=riscv32-buildroot-linux-gnu-
     export ARCH=riscv
@@ -49,5 +84,74 @@ function do_linux
     popd
 }
 
-do_buildroot && OK
-do_linux && OK
+function show_help {
+    cat << EOF
+Usage: $0 [--buildroot] [--linux] [--all] [--external-root] [--clean-build] [--help]
+
+Options:
+  --buildroot         Build Buildroot rootfs
+  --linux             Build Linux kernel
+  --all               Build both Buildroot and Linux
+  --external-root     Use external rootfs instead of initramfs
+  --clean-build       Remove entire buildroot/ and/or linux/ directories before build
+  --help              Show this message
+EOF
+    exit 1
+}
+
+BUILD_BUILDROOT=0
+BUILD_LINUX=0
+EXTERNAL_ROOT=0
+CLEAN_BUILD=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --buildroot)
+            BUILD_BUILDROOT=1
+            ;;
+        --linux)
+            BUILD_LINUX=1
+            ;;
+        --all)
+            BUILD_BUILDROOT=1
+            BUILD_LINUX=1
+            ;;
+        --external-root)
+            EXTERNAL_ROOT=1
+            ;;
+        --clean-build)
+            CLEAN_BUILD=1
+            ;;
+        --help|-h)
+            show_help
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            ;;
+    esac
+    shift
+done
+
+if [[ $BUILD_BUILDROOT -eq 0 && $BUILD_LINUX -eq 0 ]]; then
+    echo "Error: No build target specified. Use --buildroot, --linux, or --all."
+    show_help
+fi
+
+if [[ $CLEAN_BUILD -eq 1 && $BUILD_BUILDROOT -eq 1 && -d buildroot ]]; then
+    echo "Removing buildroot/ for clean build..."
+    rm -rf buildroot
+fi
+
+if [[ $CLEAN_BUILD -eq 1 && $BUILD_LINUX -eq 1 && -d linux ]]; then
+    echo "Removing linux/ for clean build..."
+    rm -rf linux
+fi
+
+if [[ $BUILD_BUILDROOT -eq 1 ]]; then
+    do_buildroot && OK
+fi
+
+if [[ $BUILD_LINUX -eq 1 ]]; then
+    do_linux && OK
+fi

--- a/scripts/rootfs_ext4.sh
+++ b/scripts/rootfs_ext4.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/bash
+
+ROOTFS_CPIO="rootfs_full.cpio"
+IMG="ext4.img"
+IMG_SIZE=$((1024 * 1024 * 1024)) # 1GB
+IMG_SIZE_BLOCKS=$((${IMG_SIZE} / 4096)) # IMG_SIZE / 4k
+
+DIR=rootfs
+
+echo "[*] Remove old rootfs directory..."
+rm -rf $DIR
+mkdir -p $DIR
+
+echo "[*] Extract CPIO"
+pushd $DIR
+cpio -idmv < ../$ROOTFS_CPIO 
+popd
+
+echo "[*] Create empty image"
+dd if=/dev/zero of=${IMG} bs=4k count=${IMG_SIZE_BLOCKS}
+
+echo "[*] Create ext4 rootfs image"
+fakeroot mkfs.ext4 -F ${IMG} -d $DIR
+
+# Show image size
+du -h ${IMG}

--- a/target/init
+++ b/target/init
@@ -1,0 +1,40 @@
+#!/bin/sh
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
+ROOTFS_DEV=/dev/vda
+
+mount -t devtmpfs devtmpfs /dev
+mount -t proc none /proc
+mount -t sysfs none /sys
+
+# use the /dev/console device node from devtmpfs if possible to not
+# confuse glibc's ttyname_r().
+# This may fail (e.g., booted with console=), and errors from exec will
+# terminate the shell, so use a subshell for the test
+if (exec 0</dev/console) 2>/dev/null; then
+    exec 0</dev/console
+    exec 1>/dev/console
+    exec 2>/dev/console
+fi
+
+echo "[*] Attempting to mount $ROOTFS_DEV"
+mkdir -p /mnt
+
+mount -t ext4 $ROOTFS_DEV /mnt
+if [ $? -ne 0 ]; then
+    echo "[!] Failed to mount $ROOTFS_DEV. Using initramfs."
+    exec /sbin/init "$@"
+fi
+
+echo "[*] $ROOTFS_DEV mounted successfully. Checking for root filesystem..."
+if [ -x /mnt/sbin/init ]; then
+    echo "[*] Valid root filesystem found. Switching root to $ROOTFS_DEV"
+    mount --move /sys  /mnt/sys
+    mount --move /proc /mnt/proc
+    mount --move /dev  /mnt/dev
+    exec switch_root -c /dev/console /mnt /sbin/init "$@"
+else
+    echo "[!] No valid root filesystem found on $ROOTFS_DEV. Using initramfs."
+    umount /mnt
+    exec /sbin/init "$@"
+fi


### PR DESCRIPTION
## Overview

Due to the 1 GiB kernel space limit on RV32-Linux, embedding large root filesystems in the kernel image can be impractical for certain testing scenarios.

This commit introduces a script to generate a mountable ext4 rootfs image and modifies the init script to support switching the root filesystem to a virtio-blk device.

During boot, the init script checks whether `/dev/vda` contains a valid rootfs. If so, it switches the root to the virtio-blk device. Otherwise, it falls back to the default initramfs.

## Testing Procedures

**1. Build Linux kernel and rootfs CPIO**
```
$ cd semu/
$ ./scripts/build-image.sh --all
```

**2. Generate external rootfs image**
```
$ ./scripts/build-image.sh --all --external-root
```

**3. Launch the simulator**
```
$ make check
```

**Expected Output**
The console output should indicate that the root filesystem was successfully mounted from `/dev/vda`:
```
[    5.383305] Run /init as init process
[*] Attempting to mount /dev/vda
[    6.029600] EXT4-fs (vda): recovery complete
[    6.029600] EXT4-fs (vda): mounted filesystem with ordered data mode. Quota mode: disabled.
[*] /dev/vda mounted successfully. Checking for root filesystem...
[*] Valid root filesystem found. Switching root to /dev/vda
```

## References

* [RISC-V 32 bit linux highmem porting](https://www.slideshare.net/dasonlin9/coscup-2020-riscv-32-bit-linux-highmem-porting?utm_source=chatgpt.com&fbclid=IwY2xjawKpYhJleHRuA2FlbQIxMQBicmlkETEyS0hISXFOaDVLcE1POFUxAR6nQXonoo_Kec04hai9f2bPIyH6uCuksqYgWxCh4OS-Ze6gqWxPQCX7NVPk1Q_aem_dcomrTK3M1dwSCXBTfRWbA)
* [Buildroot: mount another rootfs from within initramfs](https://libbits.wordpress.com/2017/03/30/buildroot-mount-another-rootfs-from-within-initramfs/?fbclid=IwY2xjawKpYkZleHRuA2FlbQIxMABicmlkETEwNkdQUnhHbHRZTUlzRER5AR5-sBZYmr9U-LMKOKtFkdUIiosPxzJvZknvWiYgF_Wogx_CsPmY216WhtasAw_aem_RFi7dagTrMBeeQ8YgQ3bMg)