### PR TITLE
PortAudio: Disable sndio in PortAudio to avoid missing -lsndio errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ ifeq ($(call has, VIRTIOSND), 1)
 portaudio/Makefile:
 	git submodule update --init portaudio
 $(PORTAUDIOLIB): portaudio/Makefile
-	cd $(dir $<) && ./configure
+	cd $(dir $<) && ./configure --without-sndio
 	$(MAKE) -C $(dir $<)
 main.o: $(PORTAUDIOLIB)
 


### PR DESCRIPTION
## Overview

Fixes a compilation error introduced in #76, where the `make all` target fails during the build of the PortAudio library on GNU/Linux systems.

The failure was caused by PortAudio's configure script automatically enabling the sndio backend when `libsndio-dev` headers are present, which leads to linker errors due to missing `-lsndio`.

To avoid this, we now explicitly pass `--without-sndio` to PortAudio’s configure script. This ensures that sndio support is disabled regardless of system headers, eliminating the need for `-lsndio` and fixing the build.

## Environment

* **Linux kernel:** 6.2.6-76060206-generic
* **Distribution:** Ubuntu 22.04.5 LTS (Jammy Jellyfish)

## Error Log

```
shengwen@pop-os:~/buildfarm/semu$ make all
  LD	semu
/usr/bin/ld: portaudio/lib/.libs/libportaudio.a(pa_sndio.o): in function `BlockingGetStreamWriteAvailable':
/home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:516: undefined reference to `sio_pollfd'
/usr/bin/ld: /home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:524: undefined reference to `sio_revents'
/usr/bin/ld: portaudio/lib/.libs/libportaudio.a(pa_sndio.o): in function `BlockingGetStreamReadAvailable':
/home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:495: undefined reference to `sio_pollfd'
/usr/bin/ld: /home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:503: undefined reference to `sio_revents'
/usr/bin/ld: portaudio/lib/.libs/libportaudio.a(pa_sndio.o): in function `BlockingWriteStream':
/home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:480: undefined reference to `sio_write'
/usr/bin/ld: portaudio/lib/.libs/libportaudio.a(pa_sndio.o): in function `BlockingReadStream':
/home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:440: undefined reference to `sio_read'
/usr/bin/ld: portaudio/lib/.libs/libportaudio.a(pa_sndio.o): in function `sndioThread':
/home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:230: undefined reference to `sio_write'
/usr/bin/ld: /home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:187: undefined reference to `sio_read'
/usr/bin/ld: portaudio/lib/.libs/libportaudio.a(pa_sndio.o): in function `OpenStream':
/home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:265: undefined reference to `sio_initpar'
/usr/bin/ld: /home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:325: undefined reference to `sio_open'
/usr/bin/ld: /home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:328: undefined reference to `sio_setpar'
/usr/bin/ld: /home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:333: undefined reference to `sio_getpar'
/usr/bin/ld: /home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:340: undefined reference to `sio_close'
/usr/bin/ld: /home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:352: undefined reference to `sio_close'
/usr/bin/ld: /home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:404: undefined reference to `sio_close'
/usr/bin/ld: /home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:382: undefined reference to `sio_close'
/usr/bin/ld: /home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:330: undefined reference to `sio_close'
/usr/bin/ld: portaudio/lib/.libs/libportaudio.a(pa_sndio.o):/home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:358: more undefined references to `sio_close' follow
/usr/bin/ld: portaudio/lib/.libs/libportaudio.a(pa_sndio.o): in function `StopStream':
/home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:612: undefined reference to `sio_stop'
/usr/bin/ld: portaudio/lib/.libs/libportaudio.a(pa_sndio.o): in function `CloseStream':
/home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:630: undefined reference to `sio_close'
/usr/bin/ld: portaudio/lib/.libs/libportaudio.a(pa_sndio.o): in function `StartStream':
/home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:563: undefined reference to `sio_start'
/usr/bin/ld: /home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:574: undefined reference to `sio_write'
/usr/bin/ld: portaudio/lib/.libs/libportaudio.a(pa_sndio.o): in function `StopStream':
/home/shengwen/buildfarm/semu/portaudio/src/hostapi/sndio/pa_sndio.c:612: undefined reference to `sio_stop'
collect2: error: ld returned 1 exit status
make: *** [Makefile:154: semu] Error 1
```