### PR TITLE
PortAudio: Enable build on macOS/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ ifeq ($(call has, VIRTIOSND), 1)
 portaudio/Makefile:
 	git submodule update --init portaudio
 $(PORTAUDIOLIB): portaudio/Makefile
-	cd $(dir $<) && ./configure --without-sndio
+	cd $(dir $<) && LDFLAGS="" ./configure --without-sndio
 	$(MAKE) -C $(dir $<)
 main.o: $(PORTAUDIOLIB)
 
@@ -168,12 +168,12 @@ DTC ?= dtc
 E :=
 S := $E $E
 
-# During boot process, he emulator manually manages the growth of ticks to 
-# suppress RCU CPU stall warnings. Thus, we need an target time to set the 
+# During boot process, the emulator manually manages the growth of ticks to
+# suppress RCU CPU stall warnings. Thus, we need an target time to set the
 # increment of ticks. According to Using RCU’s CPU Stall Detector[1], the
-# grace period for RCU CPU stalls is typically set to 21 seconds. 
-# By dividing this value by two as the expected completion time, we can 
-# provide a sufficient buffer to reduce the impact of errors and avoid 
+# grace period for RCU CPU stalls is typically set to 21 seconds.
+# By dividing this value by two as the expected completion time, we can
+# provide a sufficient buffer to reduce the impact of errors and avoid
 # RCU CPU stall warnings.
 # [1] docs.kernel.org/RCU/stallwarn.html#config-rcu-cpu-stall-timeout
 CFLAGS += -D SEMU_BOOT_TARGET_TIME=10
@@ -213,6 +213,6 @@ distclean: clean
 	$(Q)$(RM) riscv-harts.dtsi
 	$(Q)$(RM) minimal.dtb
 	$(Q)$(RM) Image rootfs.cpio
-	$(Q)$(RM) ext4.img 
+	$(Q)$(RM) ext4.img
 
 -include $(deps)


### PR DESCRIPTION
Quote from portaudio/config.log:
...
configure:3194: checking whether the C compiler works
configure:3216: gcc  -I/opt/homebrew/opt/zlib/include portaudio/lib/.libs/libportaudio.a -framework CoreServices -framework CoreFoundation -framework AudioUnit -framewo    rk AudioToolbox -framework CoreAudio -lpthread -lm mini-gdbstub/build/libgdbstub.a conftest.c  >&5
clang: error: no such file or directory: 'portaudio/lib/.libs/libportaudio.a'
...
configure:3265: error: C compiler cannot create executables
...

The ./configure script fails on macOS because LDFLAGS includes static libraries (libportaudio.a) that have not yet been built. This causes the compiler check to fail with "C compiler cannot create executables".

This patch unsets LDFLAGS during the configure step to allow the test program to compile and link successfully, enabling builds on macOS.

Related: #76


## Environment
OS: macOS/arm64 Version 15.3.1 (Darwin 24.3.0 Darwin Kernel Version 24.3.0)
Compiler: Apple clang version 16.0.0 (clang-1600.0.26.6)

## Reproduce
```shell
$ make check
```

## Expected error
```shell
git submodule update --init portaudio
cd portaudio/ && ./configure --without-sndio
checking build system type... arm-apple-darwin24.3.0
checking host system type... arm-apple-darwin24.3.0
checking target system type... arm-apple-darwin24.3.0
checking for gcc... gcc
checking whether the C compiler works... no
configure: error: in `/tmp/semu/portaudio':
configure: error: C compiler cannot create executables
See `config.log' for more details
make: *** [Makefile:100: portaudio/lib/.libs/libportaudio.a] Error 77
```