### PR TITLE
Correct MSWI/MTIMER interrupt IDs in ACLINT

### DIFF
--- a/scripts/gen-hart-dts.py
+++ b/scripts/gen-hart-dts.py
@@ -46,7 +46,7 @@ def mtimer_irq_format(nums):
         s += f"<&cpu{i}_intc 7>, "    # 7 is the MTIMER interrupt number (Machine Timer Interrupt)
     return s[:-2]
 
-def dtsi_template (cpu_list: str, plic_list, sswi_list, mtimer_list, mswi_list, clock_freq):
+def dtsi_template (cpu_list: str, plic_list, sswi_list, mswi_list, mtimer_list, clock_freq):
     return f"""/{{
     cpus {{
         #address-cells = <1>;


### PR DESCRIPTION
The DTS previously set the MSWI and MTIMER interrupt numbers incorrectly, which appears in the 'interrupts-extended' fields of the MSWI and MTIMER nodes in 'riscv-harts.dtsi'.

The Linux guests didn't break before because both the timer and IPIs are exercised via SBI calls, and the emulator services them through the SBI handlers rather than by relying on OS-visible IRQ wiring. That masked the DTS error.

Nevertheless, fixing the mapping prevents confusion during future bring-up and aligns with the RISC-V interrupt numbering.

Specifically, the 'riscv-harts.dtsi' before corrected:

```
mswi0: mswi@4400000 {
  #interrupt-cells = <0>;
  #address-cells = <0>;
  interrupt-controller;
  interrupts-extended = <&cpu0_intc 7>;
  reg = <0x4400000 0x4000>;
  compatible = "riscv,aclint-mswi";
};

mtimer0: mtimer@4300000 {
  interrupts-extended = <&cpu0_intc 3>;
  reg = <0x4300000 0x8000>;
  compatible = "riscv,aclint-mtimer";
};
```

After corrected:

```
mswi0: mswi@4400000 {
  #interrupt-cells = <0>;
  #address-cells = <0>;
  interrupt-controller;
  interrupts-extended = <&cpu0_intc 3>;
  reg = <0x4400000 0x4000>;
  compatible = "riscv,aclint-mswi";
};

mtimer0: mtimer@4300000 {
  interrupts-extended = <&cpu0_intc 7>;
  reg = <0x4300000 0x8000>;
  compatible = "riscv,aclint-mtimer";
};
```